### PR TITLE
Allow using a virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.ini
 __pycache__
+venv

--- a/imap-reencrypt.py
+++ b/imap-reencrypt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2018 Anton Semjonov
 # SPDX-License-Identiter: MIT


### PR DESCRIPTION
This PR allows a user to use a virtual environment (typically called `venv`). The venv does not clutter the operating system with normally not necessary packages.