### PR TITLE
Decryptionerror handling

### DIFF
--- a/lib/gpgmessage.py
+++ b/lib/gpgmessage.py
@@ -51,7 +51,7 @@ def decrypt(gpg, message):
         if NO_SECKEY in d.stderr:
             raise NoSecretKeyError("No secret key available.")
         else:
-            raise DecryptionError(f'Could not decrypt message. GPG exited with message "{d.status}". STDERR:\n {d.stderr}')
+            raise DecryptionError(f'Could not decrypt message. GPG exited with message "{d.status}". STDERR:\n{d.stderr}')
 
 
 # encrypt a message for an augmented recipient list

--- a/lib/gpgmessage.py
+++ b/lib/gpgmessage.py
@@ -51,7 +51,7 @@ def decrypt(gpg, message):
         if NO_SECKEY in d.stderr:
             raise NoSecretKeyError("No secret key available.")
         else:
-            raise DecryptionError(d.status)
+            raise DecryptionError(f'Could not decrypt message. GPG exited with message "{d.status}". STDERR:\n {d.stderr}')
 
 
 # encrypt a message for an augmented recipient list

--- a/lib/imap.py
+++ b/lib/imap.py
@@ -99,6 +99,10 @@ def repack_pgp(
                     with color(COLOR.YELLOW):
                         print(e)
                     mail["dirty"] = False
+                except gpgmessage.DecryptionError as e:
+                    with color(COLOR.YELLOW):
+                        print(e)
+                    mail["dirty"] = False
 
     finally:
         if not dryrun:


### PR DESCRIPTION
This PR added handling of `DecryptionErrors` in the `imap.py`.
Additionally the `d.status` was not always clear (if set at all) on `DecryptionErrors`, therefor this pull request adds the STDERR-output.

In my Mailbox I got found the following combos:
| `d.status` | Error deduced from `STDERR` |
|--------------|-------------------------------------------|
|no data was provided | gpg: invalid armor header: /a>\r\n<br/>gpg: invalid radix64 character 3E skipped<br/>gpg: CRC error; DEBEE4 - 052F47<br/>gpg: packet(5) with unknown version 185|
|decryption failed|WARNING: message was not integrity protected<br />ERROR nomdc_with_legacy_cipher 152|
|""|malformed CRC|